### PR TITLE
Основы фреймворка

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,22 +1,21 @@
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(MyApp());
+  runApp(App());
 }
 
-class MyApp extends StatelessWidget {
+class App extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(home: MyFirstStflWidget());
+    return MaterialApp(title: "App", home: MyFirstWidget());
   }
 }
 
-class MyFirstStlsWidget extends StatelessWidget {
-  int count = 0;
+class MyFirstWidget extends StatelessWidget {
+  //contextFunction() => context.runtimeType;
 
   @override
   Widget build(BuildContext context) {
-    print("StatefulWidget: ${count++}");
     return Container(
       child: Center(child: Text("Hello!")),
     );
@@ -29,11 +28,10 @@ class MyFirstStflWidget extends StatefulWidget {
 }
 
 class _MyFirstStflWidgetState extends State<MyFirstStflWidget> {
-  int count = 0;
+  contextFunction() => context.runtimeType;
 
   @override
   Widget build(BuildContext context) {
-    print("StatefulWidget: ${count++}");
     return Container(child: Center(child: Text("Hello!")));
   }
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:places/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(MyApp());
+    await tester.pumpWidget(App());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
**Ответы на вопросы**
1. Результат таков, потому что  запуск приложения происходить из метода  main(), который должен быть прописан в файле main.dart в папке lib.

4. Значение поля title в Android отображается в заголовке приложения, если перейти в "Недавние приложения".

5. Данную функцию в Stateless реализовать невозможно, так как  context недоступен, в отличие от Stateful  виджета, где context доступен. Если посмотреть  во внутрь  Stateful виджета, то можно увидеть:
`BuildContext get context => _element;`
`StatefulElement _element;`